### PR TITLE
Added a sample to write spark structured streaming aggregations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ This repository contains a set of Databricks notebooks that introduce working wi
 6.  Delete operations
 7.  Aggregation operations
 8.  Table copy operations
+9.  Write streaming aggregations

--- a/notebooks/scala/3-Structured-Streaming-Aggregations.scala
+++ b/notebooks/scala/3-Structured-Streaming-Aggregations.scala
@@ -1,0 +1,90 @@
+// Databricks notebook source
+// MAGIC %md 
+// MAGIC ## Azure Databricks
+// MAGIC ### Spark Structured streaming sample with with Azure Eventhub as source and Cosmosdb Cassandra as sink.
+// MAGIC #### Databricks cluster configuration used for this sample: 
+// MAGIC 
+// MAGIC Runtime version 6.5(Spark 2.4.5, Scala 2.11) with 
+// MAGIC [Spark Cassandra Connector 2.4.3 ](https://search.maven.org/artifact/com.datastax.spark/spark-cassandra-connector_2.11/2.4.3/jar) and [CosmosDB Cassandra API Spark helper]( https://search.maven.org/artifact/com.microsoft.azure.cosmosdb/azure-cosmos-cassandra-spark-helper/1.2.0/jar)
+// MAGIC 
+// MAGIC Sample Json data format
+// MAGIC ```json
+// MAGIC  {"PointId":"a45184f7-ac74-4f48-a4a3-2a550d079fbf","Temperature":20.41325593153632,"Humidity":55.11201771679894,"TimeStamp":"2020-06-16T14:05:14.4183386+05:30"}
+// MAGIC ```
+// MAGIC This sample consumes above json format data from eventhub and then for every distinct pointid's it creates 15 minute aggregations with avg, min and max temperature values and stores them to cosmosdb cassandra table.
+
+// COMMAND ----------
+
+import org.apache.spark.eventhubs.{ ConnectionStringBuilder, EventHubsConf, EventPosition }
+import org.apache.spark.sql._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.cassandra._
+//Spark connector
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.CassandraConnector
+
+//CosmosDB library for multiple retry
+import com.microsoft.azure.cosmosdb.cassandra
+
+// Specify connection factory for Cassandra
+spark.conf.set("spark.cassandra.connection.factory", "com.microsoft.azure.cosmosdb.cassandra.CosmosDbConnectionFactory")
+
+// Parallelism and throughput configs
+spark.conf.set("spark.cassandra.output.batch.size.rows", "1")
+spark.conf.set("spark.cassandra.connection.connections_per_executor_max", "10")
+spark.conf.set("spark.cassandra.output.concurrent.writes", "100")
+spark.conf.set("spark.cassandra.concurrent.reads", "512")
+spark.conf.set("spark.cassandra.output.batch.grouping.buffer.size", "1000")
+spark.conf.set("spark.cassandra.connection.keep_alive_ms", "60000000") //Increase this number as needed
+spark.conf.set("spark.cassandra.output.ignoreNulls","true")
+
+val connectionString = ConnectionStringBuilder("<YOUR EVENTHUB CONNECTION STRING>")
+  .setEventHubName("<YOUR EVENTHUB NAME>")
+  .build
+val eventHubsConf = EventHubsConf(connectionString)
+    .setConsumerGroup("$Default")
+    .setStartingPosition(EventPosition.fromEndOfStream)
+  
+val eventhubs = spark.readStream
+  .format("eventhubs")
+  .options(eventHubsConf.toMap)
+  .load()
+
+var sensorAggregateDF = eventhubs.select(get_json_object(($"body").cast("string"), "$.PointId").alias("PointId"),
+                                get_json_object(($"body").cast("string"), "$.TimeStamp").alias("TimeStamp"),
+                                get_json_object(($"body").cast("string"), "$.Temperature").alias("Temperature"))
+                        .select($"PointId", 
+                                to_timestamp($"TimeStamp").alias("TimeStamp"), 
+                                ($"Temperature").cast("double"))
+                        .groupBy($"PointId",window($"TimeStamp", "15 minute").as("TimeStamp")) // Create 15 minute tumbling windows for temperature aggregations for each unique point id.
+                        .agg(avg("Temperature").as("Avg"),
+                             max("Temperature").as("Max"),
+                             min("Temperature").as("Min"), 
+                             count("PointId").as("Count"))
+    
+
+sensorAggregateDF = sensorAggregateDF.select((concat($"PointId",lit("_"),$"TimeStamp.start")).as("id"), //Create Id as unique value for a given time window
+                                            $"PointId".as("pointid"),
+                                            $"TimeStamp.start".cast("string"),
+                                            $"TimeStamp.end".cast("string"),
+                                            $"Avg".as("avgtemp"),
+                                            $"Min".as("mintemp"),
+                                            $"Max".as("maxtemp"),
+                                            $"Count".as("totalcount"))
+
+
+//Write data to cosmosdb-casandra
+val keySpace = "eventsdb"
+val tableName="aggregations_15_min"
+val query = sensorAggregateDF
+                            .writeStream
+                            .foreachBatch { (batchDF: DataFrame, batchId: Long) =>
+                              batchDF.write       // Use Cassandra batch data source to write streaming out
+                                .cassandraFormat(tableName, keySpace)                               
+                                .mode("append")
+                                .save()
+                            }
+                            .outputMode("update")                            
+                            .start()
+


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* It provides an end to end sample where users can do the aggregations on streaming data and store them to cosmosdb-cassandra so that they have  pre-aggregated time-series data.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [https://github.com/sapinderpalsingh/azure-cosmos-db-cassandra-api-spark-notebooks-databricks.git]
cd [azure-cosmos-db-cassandra-api-spark-notebooks-databricks]
git checkout [master]

```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
This sample has a pre-requisite for following azure resources:
1. Azure databricks cluster (Runtime version 6.5(Spark 2.4.5, Scala 2.11))
2. Eventhub
3. Cassandra based cosmos DB with a keypace and a table with following columns:
    a. id text PK
    b. pointid text
    c. start timestamp
    d. end timestamp
    e. avgtemp double
    f. mintemp double
    g. maxtemp double
    h. totalcount int

Execution steps
1. Attach following libraries to databricks cluster from maven repository:
     a. com.datastax.spark:spark-cassandra-connector_2.11:2.4.3
     b. com.microsoft.azure.cosmosdb:azure-cosmos-cassandra-spark-helper:1.2.0
     c. com.microsoft.azure:azure-eventhubs-spark_2.11:2.3.6
2. Attach the scala notebook to your cluster(https://github.com/sapinderpalsingh/azure-cosmos-db-cassandra-api-spark-notebooks-databricks/blob/master/notebooks/scala/3-Structured-Streaming-Aggregations.scala)
3. Provide your eventhub connection string and eventhub name to the attached notebook.
4. Provide the spark cassandra-connector configurations at the cluster level.
5. Run the notebook.
6. Push some sample time-series data to eventhub, following json data format is used:
    {"PointId":"a45184f7-ac74-4f48-a4a3-2a550d079fbf","Temperature":20.41325593153632,"Humidity":55.11201771679894,"TimeStamp":"2020-06-16T14:05:14.4183386+05:30"}
```

## What to Check
Verify that the following are valid
* Verify that you have the 15 minute aggregates stored in cassandra table for each unique pointid in each 15 minute window.

## Other Information
<!-- Add any other helpful information that may be needed here. -->